### PR TITLE
Updates to align with latest changes to the draft

### DIFF
--- a/ece/compliance_test.go
+++ b/ece/compliance_test.go
@@ -1,0 +1,55 @@
+// Copyright 2016 Martijn Croonen. All rights reserved.
+// Use of this source code is governed by the MIT license, a copy of which can
+// be found in the LICENSE file.
+
+package ece
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/martijnc/gowebpush/webpush"
+)
+
+// Tests compliance with the specification.
+func TestSpecification(t *testing.T) {
+	var referenceTests = []struct {
+		receiverPublic string
+		senderPublic   string
+		senderPrivate  string
+		salt           string
+		plainText      string
+		cipherText     string
+	}{
+		{"BCEkBjzL8Z3C+oi2Q7oE5t2Np+p7osjGLg93qUP0wvqRT21EEWyf0cQDQcakQMqz4hQKYOQ3il2nNZct4HgAUQU=", "BDgpRKok2GZZDmS4r63vbJSUtcQx4Fq1V58+6+3NbZzSTlZsQiCEDTQy3CZ0ZMsqeqsEb7qW2blQHA4S48fynTk=", "vG7TmzUX9NfVR4XUGBkLAFu8iDyQe+q/165JkkN0Vlw=", "Qg61ZJRva/XBE9IEUelU3A==", "I am the walrus", "yqD2bapcx14XxUbtwjiGx69eHE3Yd6AqXcwBpT2Kd1uy"},
+	}
+
+	for _, tt := range referenceTests {
+		var senderKeys, receiverKeys webpush.KeyPair
+		receiverKeys.SetPublicKey(b64(tt.receiverPublic))
+		senderKeys.SetPublicKey(b64(tt.senderPublic))
+		senderKeys.SetPrivateKey(b64(tt.senderPrivate))
+
+		secret := webpush.CalculateSecret(&senderKeys, &receiverKeys)
+		encryptionContext := BuildDHContext(receiverKeys.PublicKey, senderKeys.PublicKey)
+
+		// Set a fixed salt for testing.
+		keys := EncryptionKeys{
+			isTest: true,
+			salt:   b64(tt.salt),
+		}
+
+		keys.CreateEncryptionKeys(secret, encryptionContext)
+
+		input := []byte(tt.plainText)
+		cipherText, err := Encrypt(input, &keys, 0)
+		if err != nil {
+			t.Error("Got error while encrypting:", err)
+		}
+
+		expectedCipherText := b64(tt.cipherText)
+		if bytes.Compare(expectedCipherText, cipherText) != 0 {
+			t.Error("Error encrypting plaintext, expected", expectedCipherText, "got", cipherText)
+		}
+	}
+}

--- a/ece/encrypt_test.go
+++ b/ece/encrypt_test.go
@@ -17,8 +17,8 @@ func TestEncrypt(t *testing.T) {
 		plaintext  string
 		ciphertext string
 	}{
-		{"NaSfkLQbZSE50BEYen1hFw==", "RYRffTtExv5u4KY3", "I am the walrus", "G6j/sfKg0qebO62yXpTCayN2KV24QitNiTvLgcFiEj0="},
-		{"xl1/N9ZH1YhzUFpi4sA4lA==", "p4oN/dLo5iM8wCva", "This is part of a test", "I7hAhx9CxXh/Lm0Vz6/Nbxny6B41QBA9rsgSc2WXsZO4NjWhaDCb"},
+		{"NaSfkLQbZSE50BEYen1hFw==", "RYRffTtExv5u4KY3", "I am the walrus", "G+GW8P7thruWfvqkU4rFbTvCs8rn13QmTR1cuIE3NFbv"},
+		{"xl1/N9ZH1YhzUFpi4sA4lA==", "p4oN/dLo5iM8wCva", "This is part of a test", "I+x8hgURjGIsfnwGyfuCZl+zqUokVhdvRZeKXLcN/NXucGwzabswRA=="},
 	}
 
 	var keys EncryptionKeys

--- a/ece/key_derivation.go
+++ b/ece/key_derivation.go
@@ -37,7 +37,7 @@ func (ek *EncryptionKeys) GetSalt() []byte {
 // CreateEncryptionKeys derives the encryption key and nonce from the input keying
 // material.
 func (ek *EncryptionKeys) CreateEncryptionKeys(secret []byte, context []byte) {
-	cekInfo := buildInfoData("Content-Encoding: aesgcm128", context)
+	cekInfo := buildInfoData("Content-Encoding: aesgcm", context)
 	nonceInfo := buildInfoData("Content-Encoding: nonce", context)
 	authInfo := []byte("Content-Encoding: auth\x00")
 

--- a/ece/key_derivation_test.go
+++ b/ece/key_derivation_test.go
@@ -24,7 +24,7 @@ func TestKeyDerivationWithAuth(t *testing.T) {
 
 	keys.CreateEncryptionKeys(secret, context)
 
-	cek := b64("xl1/N9ZH1YhzUFpi4sA4lA==")
+	cek := b64("/FzVZ2f0d6HU3PigqCFngA==")
 	nonce := b64("p4oN/dLo5iM8wCva")
 
 	if bytes.Compare(keys.nonce, nonce) != 0 {
@@ -50,7 +50,7 @@ func TestKeyDerivationWithoutAuth(t *testing.T) {
 
 	keys.CreateEncryptionKeys(secret, context)
 
-	cek := b64("NaSfkLQbZSE50BEYen1hFw==")
+	cek := b64("zsDs+WYrUwwwcDj1VGOo/g==")
 	nonce := b64("RYRffTtExv5u4KY3")
 
 	if bytes.Compare(keys.nonce, nonce) != 0 {

--- a/ece/request.go
+++ b/ece/request.go
@@ -15,9 +15,9 @@ import (
 // CryptoKeyHeader is a small struct that can be used to define the values in
 // the "Crypto-Key" header. https://tools.ietf.org/html/draft-ietf-httpbis-encryption-encoding-00#section-4
 type CryptoKeyHeader struct {
-	keyid     string
-	aesgcm128 string
-	dh        string
+	keyid  string
+	aesgcm string
+	dh     string
 }
 
 // EncryptionHeader is a small struct that can be used to define the values in
@@ -34,7 +34,7 @@ func CreateRequest(client http.Client, url string, data []byte, cryptoKey *Crypt
 	r, _ := http.NewRequest("POST", url, bytes.NewBuffer(data))
 	// Required by Firefox' push server but breaks Chrome's push server.
 	if !strings.Contains(url, "google") {
-		r.Header.Add("Content-Encoding", "aesgcm128")
+		r.Header.Add("Content-Encoding", "aesgcm")
 		r.Header.Add("Encryption-Key", cryptoKey.toString())
 	}
 	r.Header.Add("Crypto-Key", cryptoKey.toString())
@@ -52,7 +52,7 @@ func (ckh *CryptoKeyHeader) SetDHKey(publicKey []byte) {
 // SetExplicitKey sets the explicit encryption key.
 // https://tools.ietf.org/html/draft-ietf-httpbis-encryption-encoding-00#section-4.1
 func (ckh *CryptoKeyHeader) SetExplicitKey(key []byte) {
-	ckh.aesgcm128 = base64.URLEncoding.EncodeToString(key)
+	ckh.aesgcm = base64.URLEncoding.EncodeToString(key)
 }
 
 // SetKeyID sets the keyid.
@@ -70,8 +70,8 @@ func (ckh *CryptoKeyHeader) toString() string {
 	if len(ckh.dh) != 0 {
 		output += fmt.Sprintf("dh=%s;", ckh.dh)
 	}
-	if len(ckh.aesgcm128) != 0 {
-		output += fmt.Sprintf("aesgcm=%s;", ckh.aesgcm128)
+	if len(ckh.aesgcm) != 0 {
+		output += fmt.Sprintf("aesgcm=%s;", ckh.aesgcm)
 	}
 	return output
 }

--- a/ece/request.go
+++ b/ece/request.go
@@ -71,7 +71,7 @@ func (ckh *CryptoKeyHeader) toString() string {
 		output += fmt.Sprintf("dh=%s;", ckh.dh)
 	}
 	if len(ckh.aesgcm128) != 0 {
-		output += fmt.Sprintf("aesgcm128=%s;", ckh.aesgcm128)
+		output += fmt.Sprintf("aesgcm=%s;", ckh.aesgcm128)
 	}
 	return output
 }

--- a/ece/request_test.go
+++ b/ece/request_test.go
@@ -35,10 +35,10 @@ func TestEncryptionHeaderToString(t *testing.T) {
 
 func TestCryptoKeyHeaderToString(t *testing.T) {
 	var referenceTests = []struct {
-		keyid     string
-		dh        string
-		aesgcm128 string
-		expected  string
+		keyid    string
+		dh       string
+		aesgcm   string
+		expected string
 	}{
 		{"dhkey", "dh", "p4oN_dLo5iM8wCva", "keyid=dhkey;dh=dh;aesgcm=p4oN_dLo5iM8wCva;"},
 		{"", "BO0wJzfKZR2CdYChw1t_KnvzJ2I2giZyzaHxBJwAPUk-SNowGIC1pY6DPWUc66IjQzS206BsXhaxvxAniVT_s0U", "xl1_N9ZH1YhzUFpi4sA4lA", "dh=BO0wJzfKZR2CdYChw1t_KnvzJ2I2giZyzaHxBJwAPUk-SNowGIC1pY6DPWUc66IjQzS206BsXhaxvxAniVT_s0U;aesgcm=xl1_N9ZH1YhzUFpi4sA4lA;"},
@@ -51,7 +51,7 @@ func TestCryptoKeyHeaderToString(t *testing.T) {
 	for _, tt := range referenceTests {
 		header.keyid = tt.keyid
 		header.dh = tt.dh
-		header.aesgcm128 = tt.aesgcm128
+		header.aesgcm = tt.aesgcm
 
 		result = header.toString()
 		if result != tt.expected {

--- a/ece/request_test.go
+++ b/ece/request_test.go
@@ -40,10 +40,10 @@ func TestCryptoKeyHeaderToString(t *testing.T) {
 		aesgcm128 string
 		expected  string
 	}{
-		{"dhkey", "dh", "p4oN_dLo5iM8wCva", "keyid=dhkey;dh=dh;aesgcm128=p4oN_dLo5iM8wCva;"},
-		{"", "BO0wJzfKZR2CdYChw1t_KnvzJ2I2giZyzaHxBJwAPUk-SNowGIC1pY6DPWUc66IjQzS206BsXhaxvxAniVT_s0U", "xl1_N9ZH1YhzUFpi4sA4lA", "dh=BO0wJzfKZR2CdYChw1t_KnvzJ2I2giZyzaHxBJwAPUk-SNowGIC1pY6DPWUc66IjQzS206BsXhaxvxAniVT_s0U;aesgcm128=xl1_N9ZH1YhzUFpi4sA4lA;"},
-		{"testkey", "", "xl1_N9ZH1YhzUFpi4sA4lA", "keyid=testkey;aesgcm128=xl1_N9ZH1YhzUFpi4sA4lA;"},
-		{"", "BO0wJzfKZR2CdYChw1t_KnvzJ2I2giZyzaHxBJwAPUk-SNowGIC1pY6DPWUc66IjQzS206BsXhaxvxAniVT_s0U", "p4oN_dLo5iM8wCva", "dh=BO0wJzfKZR2CdYChw1t_KnvzJ2I2giZyzaHxBJwAPUk-SNowGIC1pY6DPWUc66IjQzS206BsXhaxvxAniVT_s0U;aesgcm128=p4oN_dLo5iM8wCva;"},
+		{"dhkey", "dh", "p4oN_dLo5iM8wCva", "keyid=dhkey;dh=dh;aesgcm=p4oN_dLo5iM8wCva;"},
+		{"", "BO0wJzfKZR2CdYChw1t_KnvzJ2I2giZyzaHxBJwAPUk-SNowGIC1pY6DPWUc66IjQzS206BsXhaxvxAniVT_s0U", "xl1_N9ZH1YhzUFpi4sA4lA", "dh=BO0wJzfKZR2CdYChw1t_KnvzJ2I2giZyzaHxBJwAPUk-SNowGIC1pY6DPWUc66IjQzS206BsXhaxvxAniVT_s0U;aesgcm=xl1_N9ZH1YhzUFpi4sA4lA;"},
+		{"testkey", "", "xl1_N9ZH1YhzUFpi4sA4lA", "keyid=testkey;aesgcm=xl1_N9ZH1YhzUFpi4sA4lA;"},
+		{"", "BO0wJzfKZR2CdYChw1t_KnvzJ2I2giZyzaHxBJwAPUk-SNowGIC1pY6DPWUc66IjQzS206BsXhaxvxAniVT_s0U", "p4oN_dLo5iM8wCva", "dh=BO0wJzfKZR2CdYChw1t_KnvzJ2I2giZyzaHxBJwAPUk-SNowGIC1pY6DPWUc66IjQzS206BsXhaxvxAniVT_s0U;aesgcm=p4oN_dLo5iM8wCva;"},
 	}
 
 	var header CryptoKeyHeader


### PR DESCRIPTION
This PR changes to padding length from 1 octet to two octets and renames 'aesgcm128' to 'aesgcm' in `cek_info` and the `Crypto-Key` header.

More info:
https://github.com/httpwg/http-extensions/pull/136
https://github.com/httpwg/http-extensions/pull/137